### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -3,7 +3,7 @@
     "version" : "0.0.1",
     "author" : "Wenzel P. P. Peppmeyer",
     "description" : "Provides a ?? !! equivalent that tests for definedness instread of trueness.",
-	"license" : "https://opensource.org/licenses/Artistic-2.0",
+	"license" : "Artistic-2.0",
     "provides" : {
         "Operator::defined-alternation" : "lib/Operator/defined-alternation.pm6"
     },


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license